### PR TITLE
Feature/osx commons contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@aragon/osx": "1.3.0",
     "@aragon/osx-new": "https://github.com/aragon/osx.git#develop",
     "@aragon/osx-commons-contracts": "1.4.0-alpha.5",
-    "@aragon/osx-commons-contracts-new": "https://github.com/novaknole/osx-commons-test.git",
     "@aragon/osx-commons-configs": "^0.5.0",
     "@ensdomains/ens-contracts": "^1.1.4",
     "@openzeppelin/contracts": "4.8.1",

--- a/remappings.txt
+++ b/remappings.txt
@@ -7,6 +7,5 @@ ds-test/=node_modules/ds-test/src
 @aragon/osx-new/=node_modules/@aragon/osx-new/packages/contracts/src/
 
 @aragon/osx-commons-contracts/=node_modules/@aragon/osx-commons-contracts/
-@aragon/osx-commons-contracts-new/=node_modules/@aragon/osx-commons-contracts-new/contracts/
 
 @ensdomains/ens-contracts/=node_modules/@ensdomains/ens-contracts/

--- a/src/StagedProposalProcessorSetup.sol
+++ b/src/StagedProposalProcessorSetup.sol
@@ -6,13 +6,13 @@ import {AlwaysTrueCondition} from "./utils/AlwaysTrueCondition.sol";
 import {StagedProposalProcessor as SPP} from "./StagedProposalProcessor.sol";
 
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
-import {ProxyLib} from "@aragon/osx-commons-contracts-new/src/utils/deployment/ProxyLib.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts-new/src/plugin/setup/IPluginSetup.sol";
-import {PermissionLib} from "@aragon/osx-commons-contracts-new/src/permission/PermissionLib.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
 import {
     PluginUpgradeableSetup
-} from "@aragon/osx-commons-contracts-new/src/plugin/setup/PluginUpgradeableSetup.sol";
+} from "@aragon/osx-commons-contracts/src/plugin/setup/PluginUpgradeableSetup.sol";
 
 /// @title MyPluginSetup
 /// @dev Release 1, Build 1

--- a/src/StagedProposalProcessorSetup.sol
+++ b/src/StagedProposalProcessorSetup.sol
@@ -11,6 +11,9 @@ import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/Proxy
 import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
 import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
 import {
+    PluginUUPSUpgradeable
+} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
+import {
     PluginUpgradeableSetup
 } from "@aragon/osx-commons-contracts/src/plugin/setup/PluginUpgradeableSetup.sol";
 
@@ -42,9 +45,9 @@ contract StagedProposalProcessorSetup is PluginUpgradeableSetup {
         address _dao,
         bytes calldata _data
     ) external returns (address plugin, PreparedSetupData memory preparedSetupData) {
-        (SPP.Stage[] memory stages, bytes memory metadata) = abi.decode(
+        (SPP.Stage[] memory stages, bytes memory metadata, PluginUUPSUpgradeable.TargetConfig memory targetConfig) = abi.decode(
             _data,
-            (SPP.Stage[], bytes)
+            (SPP.Stage[], bytes, PluginUUPSUpgradeable.TargetConfig)
         );
 
         // TODO: shall we deploy this with proxy as well ?
@@ -53,7 +56,7 @@ contract StagedProposalProcessorSetup is PluginUpgradeableSetup {
         plugin = IMPLEMENTATION.deployUUPSProxy(
             abi.encodeCall(
                 SPP.initialize,
-                (IDAO(_dao), address(trustedForwarder), stages, metadata)
+                (IDAO(_dao), address(trustedForwarder), stages, metadata, targetConfig)
             )
         );
 

--- a/src/utils/TrustedForwarder.sol
+++ b/src/utils/TrustedForwarder.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 
 import {Errors} from "../libraries/Errors.sol";
 
-import "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract TrustedForwarder {
     // We use array of actions even though we always revert with > 1

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -15,7 +15,7 @@ import {AlwaysTrueCondition} from "../src/utils/AlwaysTrueCondition.sol";
 import {StagedProposalProcessor as SPP} from "../src/StagedProposalProcessor.sol";
 
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
 import {PermissionManager} from "@aragon/osx/core/permission/PermissionManager.sol";
 

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -18,6 +18,9 @@ import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
 import {PermissionManager} from "@aragon/osx/core/permission/PermissionManager.sol";
+import {
+    PluginUUPSUpgradeable
+} from "@aragon/osx-commons-contracts/src/plugin/PluginUUPSUpgradeable.sol";
 
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
@@ -42,6 +45,8 @@ contract BaseTest is Assertions, Constants, Events, Fuzzers, Test {
     uint16 internal vetoThreshold = 1;
 
     SPP.ProposalType internal proposalType = SPP.ProposalType.Approval;
+
+    PluginUUPSUpgradeable.TargetConfig internal defaultTargetConfig;
 
     function setUp() public virtual {
         // deploy external needed contracts
@@ -86,13 +91,16 @@ contract BaseTest is Assertions, Constants, Events, Fuzzers, Test {
             )
         );
 
+        defaultTargetConfig.target = address(dao);
+        defaultTargetConfig.operation = PluginUUPSUpgradeable.Operation.Call;
+
         // create SPP plugin.
         sppPlugin = SPP(
             createProxyAndCall(
                 address(new SPP()),
                 abi.encodeCall(
                     SPP.initialize,
-                    (dao, address(trustedForwarder), new SPP.Stage[](0), DUMMY_METADATA)
+                    (dao, address(trustedForwarder), new SPP.Stage[](0), DUMMY_METADATA, defaultTargetConfig)
                 )
             )
         );

--- a/test/integration/concrete/advanceProposal/advanceProposal.t.sol
+++ b/test/integration/concrete/advanceProposal/advanceProposal.t.sol
@@ -8,7 +8,7 @@ import {StagedProposalProcessor as SPP} from "../../../../src/StagedProposalProc
 
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {DaoUnauthorized} from "@aragon/osx/core/utils/auth.sol";
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract AdvanceProposal_SPP_IntegrationTest is BaseTest {
     function test_RevertWhen_CallerIsNotAllowed() external {

--- a/test/integration/concrete/canExecute/canExecute.t.sol
+++ b/test/integration/concrete/canExecute/canExecute.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.8;
 import {BaseTest} from "../../../BaseTest.t.sol";
 import {PluginA} from "../../../utils/dummy-plugins/PluginA.sol";
 import {StagedProposalProcessor as SPP} from "../../../../src/StagedProposalProcessor.sol";
+import {Errors} from "../../../../src/libraries/Errors.sol";
 
 contract CanExecute_SPP_IntegrationTest is BaseTest {
     bytes32 proposalId;
@@ -49,16 +50,20 @@ contract CanExecute_SPP_IntegrationTest is BaseTest {
     }
 
     function test_WhenProposalIsNotInLastStage() external whenExistentProposal {
-        // it returns false.
+        // it should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.ProposalNotExists.selector, NON_EXISTENT_PROPOSAL_ID)
+        );
 
-        bool canExecute = sppPlugin.canExecute(uint256(NON_EXISTENT_PROPOSAL_ID));
-        assertFalse(canExecute, "canExecute");
+        sppPlugin.canExecute(uint256(NON_EXISTENT_PROPOSAL_ID));
     }
 
     function test_WhenNonExistentProposal() external {
-        // it returns false.
+        // it should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.ProposalNotExists.selector, NON_EXISTENT_PROPOSAL_ID)
+        );
 
-        bool canExecute = sppPlugin.canExecute(uint256(NON_EXISTENT_PROPOSAL_ID));
-        assertFalse(canExecute, "canExecute");
+        sppPlugin.canExecute(uint256(NON_EXISTENT_PROPOSAL_ID));
     }
 }

--- a/test/integration/concrete/canExecute/canExecute.tree
+++ b/test/integration/concrete/canExecute/canExecute.tree
@@ -6,6 +6,6 @@ CanExecute_SPP_IntegrationTest
 │   │   └── when proposal can not advance
 │   │       └── it returns false.
 │   └── when proposal is not in last stage
-│       └── it returns false.
+│       └── it should revert.
 └── when non existent proposal
-    └── it should return false.
+    └── it should revert.

--- a/test/integration/concrete/canProposalAdvance/canProposalAdvance.t.sol
+++ b/test/integration/concrete/canProposalAdvance/canProposalAdvance.t.sol
@@ -6,7 +6,7 @@ import {PluginA} from "../../../utils/dummy-plugins/PluginA.sol";
 import {StagedConfiguredSharedTest} from "../../../StagedConfiguredSharedTest.t.sol";
 import {StagedProposalProcessor as SPP} from "../../../../src/StagedProposalProcessor.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract CanProposalAdvance_SPP_IntegrationTest is BaseTest {
     bytes32 proposalId;

--- a/test/integration/concrete/createProposal/createProposal.t.sol
+++ b/test/integration/concrete/createProposal/createProposal.t.sol
@@ -8,7 +8,7 @@ import {PluginC} from "../../../utils/dummy-plugins/PluginC.sol";
 import {StagedProposalProcessor as SPP} from "../../../../src/StagedProposalProcessor.sol";
 
 import {DaoUnauthorized} from "@aragon/osx/core/utils/auth.sol";
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {PermissionLib} from "@aragon/osx/core/permission/PermissionLib.sol";
 
 contract CreateProposal_SPP_IntegrationTest is BaseTest {

--- a/test/integration/concrete/getProposalTally/getProposalTally.t.sol
+++ b/test/integration/concrete/getProposalTally/getProposalTally.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.8;
 
 import {BaseTest} from "../../../BaseTest.t.sol";
 import {PluginA} from "../../../utils/dummy-plugins/PluginA.sol";
+import {Errors} from "../../../../src/libraries/Errors.sol";
+
 import {StagedProposalProcessor as SPP} from "../../../../src/StagedProposalProcessor.sol";
 
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
@@ -173,11 +175,12 @@ contract GetProposalTally_SPP_IntegrationTest is BaseTest {
     }
 
     function test_WhenNonExistentProposal() external {
-        // it should have zero tally.
-        (uint256 votes, uint256 vetos) = sppPlugin.getProposalTally(NON_EXISTENT_PROPOSAL_ID);
+        // it should revert.
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.ProposalNotExists.selector, NON_EXISTENT_PROPOSAL_ID)
+        );
 
-        // there should be no vetos and no vote
-        assertEq(vetos, 0, "vetos");
-        assertEq(votes, 0, "votes");
+        // it should have zero tally.
+        sppPlugin.getProposalTally(NON_EXISTENT_PROPOSAL_ID);
     }
 }

--- a/test/integration/concrete/getProposalTally/getProposalTally.t.sol
+++ b/test/integration/concrete/getProposalTally/getProposalTally.t.sol
@@ -5,7 +5,7 @@ import {BaseTest} from "../../../BaseTest.t.sol";
 import {PluginA} from "../../../utils/dummy-plugins/PluginA.sol";
 import {StagedProposalProcessor as SPP} from "../../../../src/StagedProposalProcessor.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract GetProposalTally_SPP_IntegrationTest is BaseTest {
     bytes32 proposalId;

--- a/test/integration/concrete/getProposalTally/getProposalTally.tree
+++ b/test/integration/concrete/getProposalTally/getProposalTally.tree
@@ -17,4 +17,4 @@ GetProposalTally_SPP_IntegrationTest
 │                   └── when stored proposal id is valid
 │                       └── it should count unreported results of non manual, optimistic proposals with valid id.
 └── when non existent proposal
-    └── it should have zero tally.
+    └── it should revert.

--- a/test/integration/fuzz/stagedProposalProcessor.sol
+++ b/test/integration/fuzz/stagedProposalProcessor.sol
@@ -8,7 +8,7 @@ import {StagedProposalProcessor as SPP} from "../../../src/StagedProposalProcess
 
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {DaoUnauthorized} from "@aragon/osx/core/utils/auth.sol";
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract SPP_Integration_FuzzTest is BaseTest {
     function testFuzz_advanceProposal_RevertWhen_NonExistent(bytes32 _randomProposalId) external {

--- a/test/my-test.sol
+++ b/test/my-test.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.8;
+
+import {BaseTest} from "./BaseTest.t.sol";
+import {StagedProposalProcessor as SPP} from "../src/StagedProposalProcessor.sol";
+
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import "forge-std/console.sol";
+
+contract GIORGI_OE is BaseTest {
+
+
+    function test_Giorgi() external {
+        SPP.Stage[] memory stages = _createDummyStages(2, false, false, false);
+        sppPlugin.updateStages(stages);
+
+        // create proposal
+        IDAO.Action[] memory actions = _createDummyActions();
+
+        uint256 g1 = gasleft();
+        bytes32 proposalId = sppPlugin.createProposal({
+            _actions: actions,
+            _allowFailureMap: 0,
+            _metadata: DUMMY_METADATA,
+            _startDate: START_DATE
+        });
+
+        uint256 g2 = gasleft();
+
+        console.log("blaxblux");
+        console.log(g1 - g2);
+    }
+
+}

--- a/test/unit/stagedProposalProcessor/concrete/getProposal/getProposal.t.sol
+++ b/test/unit/stagedProposalProcessor/concrete/getProposal/getProposal.t.sol
@@ -33,7 +33,8 @@ contract GetProposal_SPP_UnitTest is StagedConfiguredSharedTest {
             currentStage: 0,
             stageConfigIndex: sppPlugin.getCurrentConfigIndex(),
             executed: false,
-            actions: _createDummyActions()
+            actions: _createDummyActions(),
+            targetConfig: defaultTargetConfig
         });
 
         // check proposal is correct

--- a/test/unit/stagedProposalProcessor/concrete/initialize/initialize.t.sol
+++ b/test/unit/stagedProposalProcessor/concrete/initialize/initialize.t.sol
@@ -18,7 +18,7 @@ contract Initialize_SPP_UnitTest is BaseTest {
     }
 
     modifier whenInitialized() {
-        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), DUMMY_METADATA);
+        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), DUMMY_METADATA, defaultTargetConfig);
         _;
     }
 
@@ -26,7 +26,7 @@ contract Initialize_SPP_UnitTest is BaseTest {
         // it should revert.
 
         vm.expectRevert("Initializable: contract is already initialized");
-        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), EMPTY_METADATA);
+        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), EMPTY_METADATA, defaultTargetConfig);
     }
 
     modifier whenNotInitialized() {
@@ -45,7 +45,7 @@ contract Initialize_SPP_UnitTest is BaseTest {
         vm.expectEmit({emitter: address(newSppPlugin)});
         emit Initialized(1);
 
-        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), DUMMY_METADATA);
+        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), DUMMY_METADATA, defaultTargetConfig);
 
         // check initialization values are correct
         assertEq(newSppPlugin.trustedForwarder(), address(trustedForwarder));
@@ -57,6 +57,6 @@ contract Initialize_SPP_UnitTest is BaseTest {
         // it should revert.
 
         vm.expectRevert(abi.encodeWithSelector(Errors.EmptyMetadata.selector));
-        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), EMPTY_DATA);
+        newSppPlugin.initialize(dao, address(trustedForwarder), new SPP.Stage[](0), EMPTY_DATA, defaultTargetConfig);
     }
 }

--- a/test/unit/stagedProposalProcessor/concrete/reportProposalResult/reportProposalResult.t.sol
+++ b/test/unit/stagedProposalProcessor/concrete/reportProposalResult/reportProposalResult.t.sol
@@ -5,7 +5,7 @@ import {Errors} from "../../../../../src/libraries/Errors.sol";
 import {StagedConfiguredSharedTest} from "../../../../StagedConfiguredSharedTest.t.sol";
 import {StagedProposalProcessor as SPP} from "../../../../../src/StagedProposalProcessor.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract ReportProposalResult_SPP_UnitTest is StagedConfiguredSharedTest {
     bytes32 internal proposalId;

--- a/test/unit/trustedForwarder/concrete/trustedForwarder.t.sol
+++ b/test/unit/trustedForwarder/concrete/trustedForwarder.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.8;
 import {BaseTest} from "../../../BaseTest.t.sol";
 import {Errors} from "../../../../src/libraries/Errors.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract TrustedForwarder_UnitTest is BaseTest {
     function test_RevertWhen_MoreThanOneActionIsExecuted() external {

--- a/test/unit/trustedForwarder/fuzz/trustedForwarder.t.sol
+++ b/test/unit/trustedForwarder/fuzz/trustedForwarder.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.8;
 import {BaseTest} from "../../../BaseTest.t.sol";
 import {Errors} from "../../../../src/libraries/Errors.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract TrustedForwarder_FuzzyTest is BaseTest {
     function test_AnyoneCanExecute(address _randomAddress) external {

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 
 import {StagedProposalProcessor as SPP} from "../../src/StagedProposalProcessor.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 import {StdAssertions} from "forge-std/StdAssertions.sol";
 

--- a/test/utils/Events.sol
+++ b/test/utils/Events.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 
 import {StagedProposalProcessor as SPP} from "../../src/StagedProposalProcessor.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract Events {
     event ProposalAdvanced(bytes32 indexed proposalId, uint256 indexed stageId);

--- a/test/utils/dummy-plugins/PluginA.sol
+++ b/test/utils/dummy-plugins/PluginA.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.8;
 
 import {TrustedForwarder} from "../../../src/utils/TrustedForwarder.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {
     IProposal
-} from "@aragon/osx-commons-contracts-new/src/plugin/extensions/proposal/IProposal.sol";
+} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/IProposal.sol";
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
@@ -31,20 +31,27 @@ contract PluginA is IProposal, IERC165 {
     }
 
     function createProposal(
-        bytes calldata,
+        bytes calldata _metadata,
         IDAO.Action[] calldata _actions,
         uint64 startDate,
         uint64 endDate
     ) external override returns (uint256 _proposalId) {
         if (revertOnCreateProposal) revert("revertOnCreateProposal");
 
-        _proposalId = proposalId;
+        _proposalId = createProposalId(_actions, _metadata);
         proposalId = proposalId + 1;
         actions[_proposalId] = _actions[0];
         created = true;
 
         emit ProposalCreated(_proposalId, startDate, endDate);
         return _proposalId;
+    }
+
+    function createProposalId(
+        IDAO.Action[] memory,
+        bytes memory
+    ) public view override returns (uint256) {
+        return proposalId;
     }
 
     function canExecute(uint256) public pure returns (bool) {

--- a/test/utils/dummy-plugins/PluginB.sol
+++ b/test/utils/dummy-plugins/PluginB.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.8;
 
 import {TrustedForwarder} from "../../../src/utils/TrustedForwarder.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 
 contract PluginB {
     error NotPossible();

--- a/test/utils/dummy-plugins/PluginC.sol
+++ b/test/utils/dummy-plugins/PluginC.sol
@@ -38,7 +38,7 @@ contract PluginC is IProposal, IERC165 {
     function createProposalId(
         IDAO.Action[] memory _actions,
         bytes memory _metadata
-    ) public override returns (uint256) {}
+    ) public pure override returns (uint256) {}
 
     function canExecute(uint256) public pure returns (bool) {
         // TODO: for now

--- a/test/utils/dummy-plugins/PluginC.sol
+++ b/test/utils/dummy-plugins/PluginC.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.8;
 
 import {TrustedForwarder} from "../../../src/utils/TrustedForwarder.sol";
 
-import {IDAO} from "@aragon/osx-commons-contracts-new/src/dao/IDAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {
     IProposal
-} from "@aragon/osx-commons-contracts-new/src/plugin/extensions/proposal/IProposal.sol";
+} from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/IProposal.sol";
 
 // dummy plugin that implements IProposal but the create function always reverts
 contract PluginC is IProposal, IERC165 {
@@ -34,6 +34,11 @@ contract PluginC is IProposal, IERC165 {
     ) external pure override returns (uint256) {
         revert("Always reverts");
     }
+
+    function createProposalId(
+        IDAO.Action[] memory _actions,
+        bytes memory _metadata
+    ) public override returns (uint256) {}
 
     function canExecute(uint256) public pure returns (bool) {
         // TODO: for now

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,6 @@
   dependencies:
     tslib "^2.6.2"
 
-"@aragon/osx-commons-contracts-new@https://github.com/novaknole/osx-commons-test.git":
-  version "1.0.0"
-  resolved "https://github.com/novaknole/osx-commons-test.git#2ce2c63273d3bdca56ab1822bfb803ac140e5706"
-
 "@aragon/osx-commons-contracts@1.4.0-alpha.5":
   version "1.4.0-alpha.5"
   resolved "https://registry.yarnpkg.com/@aragon/osx-commons-contracts/-/osx-commons-contracts-1.4.0-alpha.5.tgz#37a28085677c21216628ba0a05f5fe09489eb71c"


### PR DESCRIPTION
1. Uses the real `osx-commons-contracts` package.
2. implements `createProposalId`. 
3. Some comments
4. in `getProposalTally` and `canExecute`, it reverts if proposal doesn't exist instead of returning (0, 0)
