### PR TITLE
feat: add tests for sub plugins proposal creation

### DIFF
--- a/src/StagedProposalProcessor.sol
+++ b/src/StagedProposalProcessor.sol
@@ -223,18 +223,17 @@ contract StagedProposalProcessor is
         // To reduce the gas costs significantly, don't store the very
         // first stage's params in storage as they only get used in this
         // current tx and will not be needed later on for advancing.
-        bytes[] memory customParams = new bytes[](stages[index][0].plugins.length);
-        if (_proposalParams.length > 0) {
-            for (uint256 i = 0; i < _proposalParams[0].length; i++)
-                customParams[i] = _proposalParams[0][i];
-
-            for (uint256 i = 1; i < _proposalParams.length; i++) {
-                for (uint256 j = 0; j < _proposalParams[i].length; j++)
-                    createProposalParams[proposalId][uint16(i)][j] = _proposalParams[i][j];
-            }
+        for (uint256 i = 1; i < _proposalParams.length; i++) {
+            for (uint256 j = 0; j < _proposalParams[i].length; j++)
+                createProposalParams[proposalId][uint16(i)][j] = _proposalParams[i][j];
         }
 
-        _createPluginProposals(proposalId, 0, proposal.lastStageTransition, customParams);
+        _createPluginProposals(
+            proposalId,
+            0,
+            proposal.lastStageTransition,
+            _proposalParams.length > 0 ? _proposalParams[0] : new bytes[](0)
+        );
 
         emit ProposalCreated({
             proposalId: proposalId,
@@ -553,7 +552,7 @@ contract StagedProposalProcessor is
                     actions,
                     _startDate,
                     _startDate + stage.voteDuration,
-                    _stageProposalParams[i]
+                    _stageProposalParams.length > i ? _stageProposalParams[i] : new bytes(0)
                 )
             returns (uint256 pluginProposalId) {
                 pluginProposalIds[_proposalId][_stageId][

--- a/test/integration/concrete/advanceProposal/advanceProposal.t.sol
+++ b/test/integration/concrete/advanceProposal/advanceProposal.t.sol
@@ -76,7 +76,8 @@ contract AdvanceProposal_SPP_IntegrationTest is BaseTest {
         whenAllPluginsOnNextStageAreNonManual
         whenSomeSubProposalNeedExtraParams
     {
-        // it should create proposal.
+        // it should emit event.
+        // it should advance proposal.
         // it should not create sub proposals since extra param was not provided.
 
         // create proposal

--- a/test/integration/concrete/advanceProposal/advanceProposal.tree
+++ b/test/integration/concrete/advanceProposal/advanceProposal.tree
@@ -7,6 +7,8 @@ AdvanceProposal_SPP_IntegrationTest
 │   │       ├── when all plugins on next stage are non manual
 │   │       │   ├── when some sub proposal need extra params
 │   │       │   │   ├── when extra params are not provided
+│   │       │   │   │   ├── it should emit event.
+│   │       │   │   │   ├── it should advance proposal.
 │   │       │   │   │   └── it should not create sub proposals since extra param was not provided.
 │   │       │   │   ├── when extra params are provided
 │   │       │   │   │   ├── it should emit event.

--- a/test/integration/concrete/advanceProposal/advanceProposal.tree
+++ b/test/integration/concrete/advanceProposal/advanceProposal.tree
@@ -7,12 +7,19 @@ AdvanceProposal_SPP_IntegrationTest
 │   │       ├── when all plugins on next stage are non manual
 │   │       │   ├── when some sub proposal need extra params
 │   │       │   │   ├── when extra params are not provided
-│   │       │   │   │   ├── it should create proposal.
 │   │       │   │   │   └── it should not create sub proposals since extra param was not provided.
-│   │       │   │   └── when extra params are provided
+│   │       │   │   ├── when extra params are provided
+│   │       │   │   │   ├── it should emit event.
+│   │       │   │   │   ├── it should advance proposal.
+│   │       │   │   │   └── it should create sub proposals with correct extra params.
+│   │       │   │   ├── when extra params are provided and are big
+│   │       │   │   │   ├── it should emit event.
+│   │       │   │   │   ├── it should advance proposal.
+│   │       │   │   │   └── it should create sub proposals with correct extra params.
+│   │       │   │   └── when extra params are provided but not enough params // there are more sub plugins than extra params
 │   │       │   │       ├── it should emit event.
 │   │       │   │       ├── it should advance proposal.
-│   │       │   │       └── it should create sub proposals with correct extra params.
+│   │       │   │       └── it should not create sub proposals since extra param was not provided.
 │   │       │   └── when none sub proposal need extra params
 │   │       │       ├── it should emit event.
 │   │       │       ├── it should advance proposal.

--- a/test/integration/concrete/createProposal/createProposal.tree
+++ b/test/integration/concrete/createProposal/createProposal.tree
@@ -21,11 +21,22 @@ CreateProposal_SPP_IntegrationTest
 │       │           │    ├── it should create proposal.
 │       │           │    ├── it should not create sub proposals since extra param was not provided.
 │       │           │    ├── it should not store extra params.
-│       │           └── when extra params are provided
+│       │           ├── when extra params are provided
+│       │           │    ├── it should emit events.
+│       │           │    ├── it should create proposal.
+│       │           │    ├── it should create non-manual sub proposals on stage zero with all needed params.
+│       │           │    ├── it should store non-manual sub proposal ids.
+│       │           │    └── it should not create sub proposals on non zero stages.
+│       │           ├── when extra params are provided and are big
+│       │           │    ├── it should emit events.
+│       │           │    ├── it should create proposal.
+│       │           │    ├── it should create non-manual sub proposals on stage zero with all needed params.
+│       │           │    ├── it should store non-manual sub proposal ids.
+│       │           │    └── it should not create sub proposals on non zero stages.
+│       │           └── when extra params are provided but not enough params // there are more sub plugins than extra params
 │       │                ├── it should emit events.
-│       │                ├── it should create proposal.
-│       │                ├── it should create non-manual sub proposals on stage zero with all needed params.
-│       │                ├── it should store non-manual sub proposal ids.
+│       │                ├── it should create parent proposal.
+│       │                ├── it should not create sub proposals since extra param was not provided.
 │       │                └── it should not create sub proposals on non zero stages.
 │       ├── given some plugins on stage zero are manual
 │       │   ├── it should emit events.


### PR DESCRIPTION
The gas used is really similar, just proposed a new way because I found it simpler.
Mine 

| advanceProposal                                                  | 2669            | 175126 | 251976 | 372306  | 16      |
| createProposal                                                   | 18176           | 657205 | 701993 | 1040303 | 53      |


Giorgi
| advanceProposal                                                  | 2669            | 175111 | 251949 | 372279  | 16      |
| createProposal                                                   | 18176           | 657730 | 702461 | 1041546 | 53      |
